### PR TITLE
Add 'Rick May Tribute' and 'Summer' to 'tf_logic_holiday' entity

### DIFF
--- a/FGD/tf-brokk.fgd
+++ b/FGD/tf-brokk.fgd
@@ -11496,6 +11496,8 @@ target(target_destination) : "Entity to point at. Will overwrite the entity's an
         9 : "Halloween or Full Moon"
         10 : "Halloween or Full Moon or Valentines Day"
         11 : "April Fools"
+		12 : "Rick May Tribute"
+		13 : "Summer"
     ] // end holiday_type
 	tauntInHell(choices) : "Taunt In Hell?" : 0 : "Should players taunt when teleported to Hell?" = [
 		0 : "No"


### PR DESCRIPTION
This PR adds "Rick May Tribute" (holiday number 12) and "Summer" (holiday number 13) entries as valid selections in the tf_logic_holiday entity.