### PR TITLE
Add rd_robot_dispenser to the FGD

### DIFF
--- a/FGD/tf-brokk.fgd
+++ b/FGD/tf-brokk.fgd
@@ -9755,7 +9755,7 @@ target(target_destination) : "Entity to point at. Will overwrite the entity's an
 	// RD ENTITIES //
 
 @PointClass base(SBaseEntity, SBaseDiv, SEngieBuilding, SDispenserTrigger, SDispenserTriggerDefault) wirebox(helper_trigger_mins, helper_trigger_maxs) = rd_robot_dispenser : "Invisible dispenser used by the robots in Robot Destruction. Does not dispense ammo. Heal rate is fixed to 5 HP/s." [
-	defaultupgrade(choices) : "Starting Upgrade Level (Display Only)" : 0 : "Starting upgrade level of the object. Has no effect, as the dispenser gives no metal and always gives 5 HP/s regardless of level." = [
+	defaultupgrade(choices) : "Starting Upgrade Level (Display Only)" : 0 : "Starting upgrade level of the object. Has no effect, as the dispenser is hardcoded to be level 1 upon spawning." = [
 		0 : "Level 1"
 	] // end defaultupgrade
 	helper_trigger_mins(vector) : "Default Trigger (Display Only)" : "-128 -128 -128" : "Keyvalue to display the size of the default touch trigger. Has no effect in-game. Hardcoded to be 128HU."

--- a/FGD/tf-brokk.fgd
+++ b/FGD/tf-brokk.fgd
@@ -9752,6 +9752,18 @@ target(target_destination) : "Entity to point at. Will overwrite the entity's an
 
 
 
+	// RD ENTITIES //
+
+@PointClass base(SBaseEntity, SBaseDiv, SEngieBuilding, SDispenserTrigger, SDispenserTriggerDefault) wirebox(helper_trigger_mins, helper_trigger_maxs) = rd_robot_dispenser : "Invisible dispenser used by the robots in Robot Destruction. Does not dispense ammo. Heal rate is fixed to 5 HP/s." [
+	defaultupgrade(choices) : "Starting Upgrade Level (Display Only)" : 0 : "Starting upgrade level of the object. Has no effect, as the dispenser gives no metal and always gives 5 HP/s regardless of level." = [
+		0 : "Level 1"
+	] // end defaultupgrade
+	helper_trigger_mins(vector) : "Default Trigger (Display Only)" : "-128 -128 -128" : "Keyvalue to display the size of the default touch trigger. Has no effect in-game. Hardcoded to be 128HU."
+	helper_trigger_maxs(vector) : "Default Trigger (Display Only)" : "128 128 128" : "Keyvalue to display the size of the default touch trigger. Has no effect in-game. Hardcoded to be 128HU."
+] // end rd_robot_dispenser
+
+
+
 	// PHYS ENTITIES //
 
 @PointClass base(SBaseConstraint) color(150 50 50) iconsprite("editor/phys_ballsocket") = phys_ballsocket : "A constraint that keeps the position of two objects fixed, relative to the constraint's origin. It does not affect rotation." [


### PR DESCRIPTION
Added rd_robot_dispenser entity used by robots from Robot Destruction. Has no model or vgui screen, similar to the pd_dispenser. Does no dispense ammo or metal and has a fixed heal rate of 5 HP/s regardless of level. Has a healing radius of 128 HU, which can't be changed, except with a custom dispenser_touch_trigger. 

<img width="1288" height="573" alt="image" src="https://github.com/user-attachments/assets/160761a6-515f-4716-9b14-feb4969293d9" />
